### PR TITLE
docs: correct config sample file name

### DIFF
--- a/contributing/developer-setup.mdx
+++ b/contributing/developer-setup.mdx
@@ -23,9 +23,9 @@ Libredesk is a monorepo with a Go backend and a Vue.js frontend. The frontend us
   </Step>
   
   <Step title="Configure Libredesk">
-    Copy `config.toml.sample` as `config.toml` and add your configuration:
+    Copy `config.sample.toml` as `config.toml` and add your configuration:
     ```bash
-    cp config.toml.sample config.toml
+    cp config.sample.toml config.toml
     ```
   </Step>
   


### PR DESCRIPTION
In the docs the sample file is mentioned as `config.toml.sample` but the actual file is called `config.sample.toml`

ref: [First Time Setup](https://docs.libredesk.io/contributing/developer-setup#first-time-setup)